### PR TITLE
Do not remove Java Flight Recorder (jfr.jar)

### DIFF
--- a/Dockerfile.jdk.tpl
+++ b/Dockerfile.jdk.tpl
@@ -49,7 +49,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/lib/desktop \
            /opt/jdk/jre/lib/*javafx* \
            /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/jfr* \
            /opt/jdk/jre/lib/amd64/libdecora_sse.so \
            /opt/jdk/jre/lib/amd64/libprism_*.so \
            /opt/jdk/jre/lib/amd64/libfxplugins.so \

--- a/Dockerfile.jre.tpl
+++ b/Dockerfile.jre.tpl
@@ -47,7 +47,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/lib/desktop \
            /opt/jdk/jre/lib/*javafx* \
            /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/jfr* \
            /opt/jdk/jre/lib/amd64/libdecora_sse.so \
            /opt/jdk/jre/lib/amd64/libprism_*.so \
            /opt/jdk/jre/lib/amd64/libfxplugins.so \


### PR DESCRIPTION
Java Flight Recorder (JFR) is a tool for collecting diagnostic and
profiling data about a running Java application. It is frequently used
for profiling, black box analysis and support and debugging.

JFR is currently removed in anapsix/alpine-java images, although its
functionality is used by many people. Unfortunately, by adding it again
the weight of the image will increase in 600 kB.

This commit prevents JFR from being removed during the build of the
image.
