### PR TITLE
Don't remove keytool

### DIFF
--- a/7/80b15/jdk-dcevm/Dockerfile
+++ b/7/80b15/jdk-dcevm/Dockerfile
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/7/80b15/jdk/Dockerfile
+++ b/7/80b15/jdk/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/7/80b15/server-jre/Dockerfile
+++ b/7/80b15/server-jre/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/jdk-dcevm/standard/Dockerfile
+++ b/8/102b14/jdk-dcevm/standard/Dockerfile
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/102b14/jdk-dcevm/unlimited/Dockerfile
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/jdk/standard/Dockerfile
+++ b/8/102b14/jdk/standard/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/jdk/unlimited/Dockerfile
+++ b/8/102b14/jdk/unlimited/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/server-jre/standard/Dockerfile
+++ b/8/102b14/server-jre/standard/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/102b14/server-jre/unlimited/Dockerfile
+++ b/8/102b14/server-jre/unlimited/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/jdk-dcevm/standard/Dockerfile
+++ b/8/92b14/jdk-dcevm/standard/Dockerfile
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/92b14/jdk-dcevm/unlimited/Dockerfile
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/jdk/standard/Dockerfile
+++ b/8/92b14/jdk/standard/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/jdk/unlimited/Dockerfile
+++ b/8/92b14/jdk/unlimited/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/server-jre/standard/Dockerfile
+++ b/8/92b14/server-jre/standard/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/8/92b14/server-jre/unlimited/Dockerfile
+++ b/8/92b14/server-jre/unlimited/Dockerfile
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/Dockerfile.jdk-dcevm.tpl
+++ b/Dockerfile.jdk-dcevm.tpl
@@ -54,7 +54,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/Dockerfile.jdk.tpl
+++ b/Dockerfile.jdk.tpl
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \

--- a/Dockerfile.server-jre.tpl
+++ b/Dockerfile.server-jre.tpl
@@ -46,7 +46,6 @@ RUN apk upgrade --update && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
            /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/keytool \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \


### PR DESCRIPTION
We use environment variables in our docker containers to create our certificates, that way we generate new certificates depending on the environment.

https://12factor.net/

However, since keytool has been removed, we can't do that.  Would love to be able to use keytool to generate the cert at docker image startup.

[ I only need keytool in the 8/102b14/server-jre/unlimited/Dockerfile image, but for consistency, added to the all the images ]
