### PR TITLE
Generalize Java environment variables and setup

### DIFF
--- a/7/80b15/jdk-dcevm/Dockerfile
+++ b/7/80b15/jdk-dcevm/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_VERSION_BUILD=15 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/DCEVM-full-7u79-installer.jar "https://github.com/dcevm/dcevm/releases/download/full-jdk7u79%2B8/DCEVM-full-7u79-installer.jar" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip DCEVM-full-7u79-installer.jar && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/7/80b15/jdk-dcevm/Dockerfile
+++ b/7/80b15/jdk-dcevm/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/7/80b15/jdk/Dockerfile
+++ b/7/80b15/jdk/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_VERSION_BUILD=15 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/7/80b15/jdk/Dockerfile
+++ b/7/80b15/jdk/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/7/80b15/server-jre/Dockerfile
+++ b/7/80b15/server-jre/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_VERSION_BUILD=15 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/7/80b15/server-jre/Dockerfile
+++ b/7/80b15/server-jre/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/jdk-dcevm/standard/Dockerfile
+++ b/8/102b14/jdk-dcevm/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/jdk-dcevm/standard/Dockerfile
+++ b/8/102b14/jdk-dcevm/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/DCEVM-light-8u74-installer.jar "https://github.com/dcevm/dcevm/releases/download/light-jdk8u74%2B1/DCEVM-light-8u74-installer.jar" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip DCEVM-light-8u74-installer.jar && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/102b14/jdk-dcevm/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/DCEVM-light-8u74-installer.jar "https://github.com/dcevm/dcevm/releases/download/light-jdk8u74%2B1/DCEVM-light-8u74-installer.jar" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip DCEVM-light-8u74-installer.jar && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/102b14/jdk-dcevm/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/jdk/standard/Dockerfile
+++ b/8/102b14/jdk/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/jdk/standard/Dockerfile
+++ b/8/102b14/jdk/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/jdk/unlimited/Dockerfile
+++ b/8/102b14/jdk/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/jdk/unlimited/Dockerfile
+++ b/8/102b14/jdk/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/server-jre/standard/Dockerfile
+++ b/8/102b14/server-jre/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/102b14/server-jre/standard/Dockerfile
+++ b/8/102b14/server-jre/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/server-jre/unlimited/Dockerfile
+++ b/8/102b14/server-jre/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/102b14/server-jre/unlimited/Dockerfile
+++ b/8/102b14/server-jre/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/jdk-dcevm/standard/Dockerfile
+++ b/8/92b14/jdk-dcevm/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/jdk-dcevm/standard/Dockerfile
+++ b/8/92b14/jdk-dcevm/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/DCEVM-light-8u74-installer.jar "https://github.com/dcevm/dcevm/releases/download/light-jdk8u74%2B1/DCEVM-light-8u74-installer.jar" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip DCEVM-light-8u74-installer.jar && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/92b14/jdk-dcevm/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/DCEVM-light-8u74-installer.jar "https://github.com/dcevm/dcevm/releases/download/light-jdk8u74%2B1/DCEVM-light-8u74-installer.jar" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip DCEVM-light-8u74-installer.jar && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/jdk-dcevm/unlimited/Dockerfile
+++ b/8/92b14/jdk-dcevm/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/jdk/standard/Dockerfile
+++ b/8/92b14/jdk/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/jdk/standard/Dockerfile
+++ b/8/92b14/jdk/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/jdk/unlimited/Dockerfile
+++ b/8/92b14/jdk/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/jdk/unlimited/Dockerfile
+++ b/8/92b14/jdk/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/server-jre/standard/Dockerfile
+++ b/8/92b14/server-jre/standard/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/8/92b14/server-jre/standard/Dockerfile
+++ b/8/92b14/server-jre/standard/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=standard \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/server-jre/unlimited/Dockerfile
+++ b/8/92b14/server-jre/unlimited/Dockerfile
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=unlimited \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/8/92b14/server-jre/unlimited/Dockerfile
+++ b/8/92b14/server-jre/unlimited/Dockerfile
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=server-jre \
     JAVA_JCE=unlimited \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=2.23-r3 \
     LANG=C.UTF-8
 

--- a/Dockerfile.jdk-dcevm.tpl
+++ b/Dockerfile.jdk-dcevm.tpl
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_VERSION_BUILD=%JVM_BUILD% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 
@@ -25,59 +26,59 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /tmp/dcevm && \
+    mkdir -p /tmp/dcevm && \
     curl -L -o /tmp/dcevm/%DCEVM_INSTALLER_NAME% "%DCEVM_INSTALLER_URL%" && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    tar -C ${JAVA_BASE_DIR} -xf /tmp/java.tar && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     cd /tmp/dcevm && \
     unzip %DCEVM_INSTALLER_NAME% && \
-    mkdir -p /opt/jdk/jre/lib/amd64/dcevm && \
-    cp linux_amd64_compiler2/product/libjvm.so /opt/jdk/jre/lib/amd64/dcevm/libjvm.so && \
+    mkdir -p ${JAVA_HOME}/jre/lib/amd64/dcevm && \
+    cp linux_amd64_compiler2/product/libjvm.so ${JAVA_HOME}/jre/lib/amd64/dcevm/libjvm.so && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/Dockerfile.jdk-dcevm.tpl
+++ b/Dockerfile.jdk-dcevm.tpl
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 

--- a/Dockerfile.jdk.tpl
+++ b/Dockerfile.jdk.tpl
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_VERSION_BUILD=%JVM_BUILD% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" >&2 && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/*src.zip \
-           /opt/jdk/lib/missioncontrol \
-           /opt/jdk/lib/visualvm \
-           /opt/jdk/lib/*javafx* \
-           /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/Dockerfile.jdk.tpl
+++ b/Dockerfile.jdk.tpl
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 

--- a/Dockerfile.server-jre.tpl
+++ b/Dockerfile.server-jre.tpl
@@ -11,8 +11,9 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_VERSION_BUILD=%JVM_BUILD% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
-    JAVA_HOME=/opt/jdk \
-    PATH=${PATH}:/opt/jdk/bin \
+    JAVA_BASE_DIR=/opt \
+    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
+    PATH=${PATH}:${JAVA_HOME}/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 
@@ -25,51 +26,51 @@ RUN apk upgrade --update && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    mkdir /opt && \
+    mkdir -p ${JAVA_BASE_DIR} && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
       http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
       http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \
-    find /opt/jdk/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
-    cd /opt/jdk/ && ln -s ./jre/bin ./bin && \
+    ln -s ${JAVA_BASE_DIR}/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    find ${JAVA_HOME}/ -maxdepth 1 -mindepth 1 | grep -v jre | xargs rm -rf && \
+    cd ${JAVA_HOME}/ && ln -s ./jre/bin ./bin && \
     if [ "${JAVA_JCE}" == "unlimited" ]; then echo "Installing Unlimited JCE policy" && \
       curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip \
         http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION_MAJOR}/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
       cd /tmp && unzip /tmp/jce_policy-${JAVA_VERSION_MAJOR}.zip && \
-      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar /opt/jdk/jre/lib/security/; \
+      cp -v /tmp/UnlimitedJCEPolicyJDK8/*.jar ${JAVA_HOME}/jre/lib/security/; \
     fi && \
     sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=30/ $JAVA_HOME/jre/lib/security/java.security && \
     apk del curl glibc-i18n && \
-    rm -rf /opt/jdk/jre/plugin \
-           /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
-           /opt/jdk/jre/bin/orbd \
-           /opt/jdk/jre/bin/pack200 \
-           /opt/jdk/jre/bin/policytool \
-           /opt/jdk/jre/bin/rmid \
-           /opt/jdk/jre/bin/rmiregistry \
-           /opt/jdk/jre/bin/servertool \
-           /opt/jdk/jre/bin/tnameserv \
-           /opt/jdk/jre/bin/unpack200 \
-           /opt/jdk/jre/lib/javaws.jar \
-           /opt/jdk/jre/lib/deploy* \
-           /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
-           /opt/jdk/jre/lib/amd64/libdecora_sse.so \
-           /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
-           /opt/jdk/jre/lib/amd64/libglass.so \
-           /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
-           /opt/jdk/jre/lib/oblique-fonts \
-           /opt/jdk/jre/lib/plugin.jar \
+    rm -rf ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 

--- a/Dockerfile.server-jre.tpl
+++ b/Dockerfile.server-jre.tpl
@@ -12,8 +12,8 @@ ENV JAVA_VERSION_MAJOR=%JVM_MAJOR% \
     JAVA_PACKAGE=%JVM_PACKAGE% \
     JAVA_JCE=%JAVA_JCE% \
     JAVA_BASE_DIR=/opt \
-    JAVA_HOME=${JAVA_BASE_DIR}/jdk \
-    PATH=${PATH}:${JAVA_HOME}/bin \
+    JAVA_HOME=/opt/jdk \
+    PATH=${PATH}:/opt/jdk/bin \
     GLIBC_VERSION=%GLIBC_VERSION% \
     LANG=C.UTF-8
 


### PR DESCRIPTION
In order for easier forking, rearangement of installations all paths must be as parametric
as possible.

This pach achieves this by:
- Introduce new variable `JAVA_BASE_DIR` which points to the base where all JRE/JDK will be installed
- Ammend `JAVA_HOME` and `PATH` to include `JAVA_BASE_DIR`
- convert all `mkdir` to `mkdir -p` to allow for deeper structures
- Use `JAVA_BASE_DIR` and `JAVA_HOME` everywhere possible
- Use `JAVA_HOME` in cleanup step
