### PR TITLE
Fix 'Exception in thread "main" java.lang.NoClassDefFoundError: javafx/util/Pair'

### DIFF
--- a/8/121b13/server-jre/standard/Dockerfile
+++ b/8/121b13/server-jre/standard/Dockerfile
@@ -56,16 +56,10 @@ RUN set -ex && \
            /opt/jdk/jre/lib/javaws.jar \
            /opt/jdk/jre/lib/deploy* \
            /opt/jdk/jre/lib/desktop \
-           /opt/jdk/jre/lib/*javafx* \
-           /opt/jdk/jre/lib/*jfx* \
            /opt/jdk/jre/lib/amd64/libdecora_sse.so \
            /opt/jdk/jre/lib/amd64/libprism_*.so \
-           /opt/jdk/jre/lib/amd64/libfxplugins.so \
            /opt/jdk/jre/lib/amd64/libglass.so \
            /opt/jdk/jre/lib/amd64/libgstreamer-lite.so \
-           /opt/jdk/jre/lib/amd64/libjavafx*.so \
-           /opt/jdk/jre/lib/amd64/libjfx*.so \
-           /opt/jdk/jre/lib/ext/jfxrt.jar \
            /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \


### PR DESCRIPTION
```
Exception in thread "main" java.lang.NoClassDefFoundError: javafx/util/Pair
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethods(Class.java:1975)
	at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:688)
	at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:380)
	at com.google.inject.internal.ConstructorBindingImpl.getInternalDependencies(ConstructorBindingImpl.java:164)
	at com.google.inject.internal.InjectorImpl.getInternalDependencies(InjectorImpl.java:613)
	at com.google.inject.internal.InjectorImpl.cleanup(InjectorImpl.java:569)
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:555)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:884)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:805)
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:282)
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:214)
	at com.google.inject.internal.InjectorImpl.getInternalFactory(InjectorImpl.java:890)
	at com.google.inject.internal.FactoryProxy.notify(FactoryProxy.java:46)
	at com.google.inject.internal.ProcessedBindingData.runCreationListeners(ProcessedBindingData.java:50)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:134)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
	at com.google.inject.Guice.createInjector(Guice.java:96)
	at com.google.inject.Guice.createInjector(Guice.java:84)
	at play.api.inject.guice.GuiceBuilder.injector(GuiceInjectorBuilder.scala:181)
	at play.api.inject.guice.GuiceApplicationBuilder.build(GuiceApplicationBuilder.scala:123)
	at play.api.inject.guice.GuiceApplicationLoader.load(GuiceApplicationLoader.scala:21)
	at play.core.server.ProdServerStart$.start(ProdServerStart.scala:47)
	at play.core.server.ProdServerStart$.main(ProdServerStart.scala:22)
	at play.core.server.ProdServerStart.main(ProdServerStart.scala)
Caused by: java.lang.ClassNotFoundException: javafx.util.Pair
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 26 more
```