### PR TITLE
Change one new version of alpine and glibc

### DIFF
--- a/7/80b15/jdk/Dockerfile
+++ b/7/80b15/jdk/Dockerfile
@@ -13,7 +13,7 @@ ENV JAVA_VERSION_MAJOR=7 \
     JAVA_JCE=standard \
     JAVA_HOME=/opt/jdk \
     PATH=${PATH}:/opt/jdk/bin \
-    GLIBC_VERSION=2.23-r3 \
+    GLIBC_VERSION=2.25-r0 \
     LANG=C.UTF-8
 
 # do all in one step

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This image is based on [AlpineLinux](http://alpinelinux.org/) to keep the size d
 Includes BASH, since many Java applications like to have convoluted BASH start-up scripts.
 
 ### Versions/tags
-All tags upgraded to `alpine:3.4`
+All tags upgraded to `alpine:3.5` only for jdk7 
 
 #### MAJOR TAGGING UPDATE
 To allow selection of specific Java version, a **major retagging is taking place**.
@@ -52,7 +52,7 @@ Latest Oracle Java 7 JDK (plus DCEVM variant):
 
 ### Usage
 
-Example: 
+Example:
 
     docker run -it --rm anapsix/alpine-java java -version
 


### PR DESCRIPTION
Hi,  i modify  the version of alpine for 3.5 (last stable) and glibc for  one version without security problem, only for jdk 7