### PR TITLE
Java8 with nashorn engine

### DIFF
--- a/8/162b12/jdk-dcevm/standard/Dockerfile
+++ b/8/162b12/jdk-dcevm/standard/Dockerfile
@@ -58,7 +58,6 @@ RUN set -ex && \
            /opt/jdk/lib/*javafx* \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -80,7 +79,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \

--- a/8/162b12/jdk-dcevm/unlimited/Dockerfile
+++ b/8/162b12/jdk-dcevm/unlimited/Dockerfile
@@ -58,7 +58,6 @@ RUN set -ex && \
            /opt/jdk/lib/*javafx* \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -80,7 +79,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \

--- a/8/162b12/jdk/standard/Dockerfile
+++ b/8/162b12/jdk/standard/Dockerfile
@@ -51,7 +51,6 @@ RUN set -ex && \
            /opt/jdk/lib/*javafx* \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -73,7 +72,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \

--- a/8/162b12/jdk/unlimited/Dockerfile
+++ b/8/162b12/jdk/unlimited/Dockerfile
@@ -51,7 +51,6 @@ RUN set -ex && \
            /opt/jdk/lib/*javafx* \
            /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -73,7 +72,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \

--- a/8/162b12/server-jre/standard/Dockerfile
+++ b/8/162b12/server-jre/standard/Dockerfile
@@ -49,7 +49,6 @@ RUN set -ex && \
     apk del curl glibc-i18n && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -71,7 +70,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \

--- a/8/162b12/server-jre/unlimited/Dockerfile
+++ b/8/162b12/server-jre/unlimited/Dockerfile
@@ -49,7 +49,6 @@ RUN set -ex && \
     apk del curl glibc-i18n && \
     rm -rf /opt/jdk/jre/plugin \
            /opt/jdk/jre/bin/javaws \
-           /opt/jdk/jre/bin/jjs \
            /opt/jdk/jre/bin/orbd \
            /opt/jdk/jre/bin/pack200 \
            /opt/jdk/jre/bin/policytool \
@@ -71,7 +70,6 @@ RUN set -ex && \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/* && \


### PR DESCRIPTION
This PR lets Java 8 image to retain Nashorn engine and JJS tool to invoke it. See #50 . 

alpine-java:8_jdk_unlimited size increased by 2MB after this change (173MB -> 175MB), as shown in `docker images`. 

Size difference in Compressed build on Docker hub - 
https://hub.docker.com/r/anapsix/alpine-java/tags/  -> 8_jdk_unlimited -> 66 MB
https://hub.docker.com/r/javastreets/alpine-java/tags/  -> 8_jdk_unlimited -> 68 MB
